### PR TITLE
add match expressions

### DIFF
--- a/src/logic/parser.ts
+++ b/src/logic/parser.ts
@@ -3,6 +3,7 @@ import {Rule as ConfigRule} from "../models/ui.tsx";
 import {
     Expr, Grammar,
     makeAtom, makeGrammar,
+    makeMatch,
     makeRange,
     makeRef, makeRule,
     makeSeq,
@@ -81,6 +82,32 @@ export class Parser {
         }
 
         return makeRef(refName);
+    }
+
+    private parseMatch(): Expr {
+        let indexString = ''
+
+        if (!this.consume('#')) {
+            throw new Error("Expected number sign to start match");
+        }
+
+        while (this.hasMoreInput()) {
+            const char = this.peek()!;
+
+            if (char === '#') {
+                break
+            } else {
+                // Part of the index; append the character and advance
+                indexString += char;
+                this.advancePosition(false);
+            }
+        }
+
+        if (!this.consume('#')) {
+            throw new Error("Expected number sign to end match");
+        }
+
+        return makeMatch(parseInt(indexString));
     }
 
     private isRefCharacter(char: string | null, lead: boolean | null = null): boolean {
@@ -170,6 +197,8 @@ export class Parser {
             return this.parseOption();
         } else if (char === "[") {
             return this.parseGroup();
+        } else if (char === "#") {
+            return this.parseMatch();
         } else if (this.isRefCharacter(char)) {
             return this.parseRef();
         } else {

--- a/src/models/grammar.ts
+++ b/src/models/grammar.ts
@@ -14,6 +14,7 @@ export type Rule = {
 export type Expr =
     | { tag: 'Atom', value: string }
     | { tag: 'Ref', rule: string }
+    | { tag: 'Match', index: number }
     | { tag: 'Seq', items: Expr[] }
     | { tag: 'Choice', items: WeightedExpr[] }
     | { tag: 'Quantifier', expr: Expr, min: number, max: number }
@@ -25,9 +26,10 @@ export type WeightedExpr = {
 
 // Utility functions
 
-export const makeAtom = (atom: string): Expr => ({tag: "Atom", value: atom});
-export const makeRef = (rule: string): Expr => ({tag: "Ref", rule: rule});
-export const makeSeq = (items: Expr[]): Expr => ({tag: "Seq", items: items});
+export const makeAtom = (value: string): Expr => ({tag: "Atom", value});
+export const makeRef = (rule: string): Expr => ({tag: "Ref", rule});
+export const makeMatch = (index: number): Expr => ({tag: "Match", index});
+export const makeSeq = (items: Expr[]): Expr => ({tag: "Seq", items});
 
 export const makeWeighted = (expr: Expr, weight: number | null): WeightedExpr => ({expr: expr, weight: weight ?? 1.0})
 export const makeChoice = (items: Expr[]): Expr => ({tag: "Choice", items: items.map(makeWeighted)});


### PR DESCRIPTION
I discovered your word generator yesterday and it's the best one I've come across! I thought a cool feature to add to it would be to allow indexing on rewrite rules, so that you could do things like:
- metathesis: C.V.r.C > #0#.r.#1#.#2#
- epenthesis: Consonant.Consonant > #1#.a.#0#
- gemination: StressedSchwa.C.V > #0#.#1#{2}.#2#